### PR TITLE
feat(release): add Repology badge for FlClashX version tracking

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -40,9 +40,10 @@
         <tr>
             <td>Linux</td>
             <td>
-                <a href="https://github.com/pluralplay/FlClashX/releases/download/vVERSION/FlClashX-VERSION-linux-amd64.AppImage"><img src="https://img.shields.io/badge/AppImage-x64-f84e29.svg?logo=linux"> </a><br>
-                <a href="https://github.com/pluralplay/FlClashX/releases/download/vVERSION/FlClashX-VERSION-linux-amd64.deb"><img src="https://img.shields.io/badge/DebPackage-x64-FF9966.svg?logo=debian"> </a><br>
-                <a href="https://github.com/pluralplay/FlClashX/releases/download/vVERSION/FlClashX-VERSION-linux-amd64.deb"><img src="https://img.shields.io/badge/RpmPackage-x64-F1B42F.svg?logo=redhat"> </a>
+                <a href="https://github.com/pluralplay/FlClashX/releases/download/vVERSION/FlClashX-VERSION-linux-amd64.AppImage"><img src="https://img.shields.io/badge/AppImage-x64-f84e29.svg?logo=linux"></a><br>
+                <a href="https://github.com/pluralplay/FlClashX/releases/download/vVERSION/FlClashX-VERSION-linux-amd64.deb"><img src="https://img.shields.io/badge/DebPackage-x64-FF9966.svg?logo=debian"></a><br>
+                <a href="https://github.com/pluralplay/FlClashX/releases/download/vVERSION/FlClashX-VERSION-linux-amd64.deb"><img src="https://img.shields.io/badge/RpmPackage-x64-F1B42F.svg?logo=redhat"></a><br>
+                <a href="https://repology.org/project/flclashx/versions"><img src="https://repology.org/badge/vertical-allrepos/flclashx.svg"></a>
             </td>
         </tr>
     </tbody>


### PR DESCRIPTION
This pull request makes a minor update to the `.github/release_template.md` file by improving the presentation of Linux package download links and adding a link to Repology for package version tracking.

* Release template improvements:
  * Added a line break after the RPM package badge and included a Repology badge for tracking package versions across repositories. (.github/release_template.md)