### PR TITLE
feat(headers): add flclashx-closeconnections header to toggle auto-close

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -328,6 +328,25 @@ class AppController {
             .toSet();
         applySubscriptionSettings(settings);
       }
+
+      // flclashx-closeconnections: explicit toggle for the
+      // "auto-close connections on server change" setting.
+      // Accepted values: "true" / "false" (case-insensitive).
+      final closeHeader = headers['flclashx-closeconnections'];
+      if (closeHeader != null) {
+        final raw = closeHeader.trim().toLowerCase();
+        if (raw == 'true' || raw == 'false') {
+          final value = raw == 'true';
+          _ref.read(appSettingProvider.notifier).updateState(
+                (state) => state.copyWith(closeConnections: value),
+              );
+          commonPrint.log(
+              "Applied flclashx-closeconnections: closeConnections=$value");
+        } else {
+          commonPrint.log(
+              "Invalid flclashx-closeconnections value: '$closeHeader' (expected 'true' or 'false')");
+        }
+      }
     } catch (e) {
       commonPrint.log("Failed to apply provider settings: $e");
     }


### PR DESCRIPTION
## Summary
Adds a new subscription response header `flclashx-closeconnections` that lets a provider toggle the **"Auto close connections on server change"** application setting (`appSettingProvider.closeConnections`).

## Header
| Name | Values | Effect |
|------|--------|--------|
| `flclashx-closeconnections` | `true` / `false` (case-insensitive) | Sets `appSetting.closeConnections` |

## Behavior
- Honored only when `flclashx-custom: add` (new profile) or `flclashx-custom: update` (every refresh) — same gate as the other `flclashx-*` headers.
- Skipped when the user has **Override provider settings** enabled.
- Invalid values are logged and ignored (setting remains unchanged).
- Header is auto-extracted by the existing universal `flclashx-*` parser in `lib/models/profile.dart`, so no parsing infrastructure changes are needed.

## Files changed
- `lib/controller.dart` — 19 lines added inside `_applyProviderSettings`.

## Testing
Built locally on Windows via the existing CI workflow and verified against a Remnawave panel sending:
flclashx-custom: update
flclashx-closeconnections: true

After subscription refresh, the **Автозакрытие соединений** toggle in app settings flips accordingly. Logs:
Applied flclashx-closeconnections: closeConnections=true