### PR TITLE
feat(headers): add flclashx-openlogs to toggle openLogs via subscription

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -328,6 +328,25 @@ class AppController {
             .toSet();
         applySubscriptionSettings(settings);
       }
+
+      // flclashx-openlogs: explicit toggle for the application
+      // event logging setting (controls appSetting.openLogs).
+      // Accepted values: "true" / "false" (case-insensitive).
+      final openLogsHeader = headers['flclashx-openlogs'];
+      if (openLogsHeader != null) {
+        final raw = openLogsHeader.trim().toLowerCase();
+        if (raw == 'true' || raw == 'false') {
+          final value = raw == 'true';
+          _ref.read(appSettingProvider.notifier).updateState(
+                (state) => state.copyWith(openLogs: value),
+              );
+          commonPrint.log(
+              "Applied flclashx-openlogs: openLogs=$value");
+        } else {
+          commonPrint.log(
+              "Invalid flclashx-openlogs value: '$openLogsHeader' (expected 'true' or 'false')");
+        }
+      }
     } catch (e) {
       commonPrint.log("Failed to apply provider settings: $e");
     }


### PR DESCRIPTION
## Summary
Adds a new subscription response header `flclashx-openlogs` that lets a provider toggle the **"Logcat / event logging"** application setting (`appSettingProvider.openLogs`).

## Header
| Name | Values | Effect |
|------|--------|--------|
| `flclashx-openlogs` | `true` / `false` (case-insensitive) | Sets `appSetting.openLogs` |

## Behavior
- Honored only when `flclashx-custom: add` (new profile) or `flclashx-custom: update` (every refresh) — same gate as the other `flclashx-*` headers.
- Skipped when the user has **Override provider settings** enabled.
- Invalid values are logged and ignored.
- Auto-extracted by the existing `flclashx-*` parser; no infrastructure changes required.

## Files changed
- `lib/controller.dart` — 19 lines added inside `_applyProviderSettings`.

## Testing
Built locally on Windows via the existing CI workflow and verified against a Remnawave panel sending:
flclashx-custom: update
flclashx-openlogs: false

After subscription refresh, the **Журналирование** toggle flips accordingly. Logs:
Applied flclashx-openlogs: openLogs=false